### PR TITLE
from . import

### DIFF
--- a/octoprint_GcodeAnalyzer/__init__.py
+++ b/octoprint_GcodeAnalyzer/__init__.py
@@ -4,7 +4,7 @@ from octoprint.filemanager.analysis import AbstractAnalysisQueue
 from octoprint.filemanager.analysis import GcodeAnalysisQueue
 
 import octoprint.plugin
-import analyze_slic3r
+from . import analyze_slic3r
 
 class FileCommentGcodeAnalysisQueue(GcodeAnalysisQueue):
   """Extracts gcode analysis from the comments in the code."""


### PR DESCRIPTION
For users that don't have cwd in the python path.

Fixes https://github.com/eyal0/OctoPrint-GcodeAnalyzer/issues/1